### PR TITLE
chore: migrates back to PD

### DIFF
--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -1,5 +1,5 @@
 apiVersion: greenhouse.sap/v1alpha1
-kind: ClusterPluginDefinition
+kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:


### PR DESCRIPTION
This is the second part of https://github.com/cloudoperators/controlplane-operations/pull/2

When migrating from cluster scoped PluginDefinitions to 
- [ClusterPluginDefinitions](https://github.com/cloudoperators/greenhouse/issues/1214) (cluster scope)
- [PluginDefinitions](https://github.com/cloudoperators/greenhouse/issues/1004) (ns scope)

We first moved every PD to CPD for a non-breaking transition and now move everything back to PD with the release and rollout of the new feature.

Please do not merge!