### PR TITLE
Add webhook-injector propagation alerts

### DIFF
--- a/charts/controlplane-operations/Chart.yaml
+++ b/charts/controlplane-operations/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controlplane-operations
-version: 1.1.12
+version: 1.1.13
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Controlplane clusters.
 maintainers:
   - name: Vladimir Videlov (d051408)

--- a/charts/controlplane-operations/Chart.yaml
+++ b/charts/controlplane-operations/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controlplane-operations
-version: 1.1.10
+version: 1.1.11
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Controlplane clusters.
 maintainers:
   - name: Vladimir Videlov (d051408)

--- a/charts/controlplane-operations/Chart.yaml
+++ b/charts/controlplane-operations/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controlplane-operations
-version: 1.1.11
+version: 1.1.12
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Controlplane clusters.
 maintainers:
   - name: Vladimir Videlov (d051408)

--- a/charts/controlplane-operations/alerts/controlplane-remote.yaml
+++ b/charts/controlplane-operations/alerts/controlplane-remote.yaml
@@ -103,7 +103,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookTargetStampErrors | default false) }}
   - alert: WebhookTargetStampErrors
     expr: |
-      sum(rate(webhook_injector_target_stamps_total{result="error"}[10m])) > 0
+      sum(rate(webhook_injector_target_stamps_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookTargetStampErrors" "for" "10m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -119,7 +119,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceStampErrors | default false) }}
   - alert: WebhookManagedResourceStampErrors
     expr: |
-      sum(rate(webhook_injector_managed_resource_stamps_total{result="error"}[10m])) > 0
+      sum(rate(webhook_injector_managed_resource_stamps_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookManagedResourceStampErrors" "for" "10m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -135,7 +135,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceUnhealthy | default false) }}
   - alert: WebhookManagedResourceUnhealthy
     expr: |
-      sum(rate(webhook_injector_managed_resource_unhealthy_total[15m])) > 0
+      sum(rate(webhook_injector_managed_resource_unhealthy_total[5m])) > 0
     for: {{ dig "WebhookManagedResourceUnhealthy" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -151,7 +151,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceKeepObjectsViolation | default false) }}
   - alert: WebhookManagedResourceKeepObjectsViolation
     expr: |
-      sum(rate(webhook_injector_managed_resource_keep_objects_violations_total[15m])) > 0
+      sum(rate(webhook_injector_managed_resource_keep_objects_violations_total[5m])) > 0
     for: {{ dig "WebhookManagedResourceKeepObjectsViolation" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -167,7 +167,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceForceReconcilePatchErrors | default false) }}
   - alert: WebhookManagedResourceForceReconcilePatchErrors
     expr: |
-      sum(rate(webhook_injector_managed_resource_force_reconcile_total{result="error"}[15m])) > 0
+      sum(rate(webhook_injector_managed_resource_force_reconcile_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}

--- a/charts/controlplane-operations/alerts/controlplane-remote.yaml
+++ b/charts/controlplane-operations/alerts/controlplane-remote.yaml
@@ -99,3 +99,83 @@ groups:
       summary: "Webhook certificate is about to expire."
       description: "Certificate expires in less than 3 days."
 {{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookTargetStampErrors | default false) }}
+  - alert: WebhookTargetStampErrors
+    expr: |
+      sum(rate(webhook_injector_target_stamps_total{result="error"}[10m])) > 0
+    for: {{ dig "WebhookTargetStampErrors" "for" "10m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookTargetStampErrors" "severity" "critical" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-target-stamp-errors/ #TODO: add playbook
+      service: {{ dig "WebhookTargetStampErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookTargetStampErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "Webhook caBundle apply to target cluster is failing."
+      description: "webhook-injector failed to apply MutatingWebhookConfiguration or ValidatingWebhookConfiguration to the target cluster — the freshly rotated caBundle is NOT reaching the admission webhooks and subsequent CR writes may be rejected with TLS errors."
+{{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceStampErrors | default false) }}
+  - alert: WebhookManagedResourceStampErrors
+    expr: |
+      sum(rate(webhook_injector_managed_resource_stamps_total{result="error"}[10m])) > 0
+    for: {{ dig "WebhookManagedResourceStampErrors" "for" "10m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookManagedResourceStampErrors" "severity" "critical" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-managed-resource-stamp-errors/ #TODO: add playbook
+      service: {{ dig "WebhookManagedResourceStampErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookManagedResourceStampErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "Webhook caBundle stamp on ManagedResource Secret is failing."
+      description: "webhook-injector failed to stamp the freshly rotated caBundle onto a labeled ManagedResource Secret on the hosting cluster — the embedded CRDs will not refresh in the shoot via gardener-resource-manager, and conversion webhooks for those CRDs will fail TLS once the old cert is pruned."
+{{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceUnhealthy | default false) }}
+  - alert: WebhookManagedResourceUnhealthy
+    expr: |
+      sum(rate(webhook_injector_managed_resource_unhealthy_total[15m])) > 0
+    for: {{ dig "WebhookManagedResourceUnhealthy" "for" "15m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookManagedResourceUnhealthy" "severity" "warning" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-managed-resource-unhealthy/ #TODO: add playbook
+      service: {{ dig "WebhookManagedResourceUnhealthy" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookManagedResourceUnhealthy" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "ManagedResource reported as not healthy by gardener-resource-manager."
+      description: "A labeled ManagedResource has ResourcesApplied or ResourcesHealthy condition with Status != True, meaning GRM is unable to apply or keep the resources healthy in the shoot. caBundle propagation to shoot-side CRDs is degraded; check the MR's status conditions for Reason/Message."
+{{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceKeepObjectsViolation | default false) }}
+  - alert: WebhookManagedResourceKeepObjectsViolation
+    expr: |
+      sum(rate(webhook_injector_managed_resource_keep_objects_violations_total[15m])) > 0
+    for: {{ dig "WebhookManagedResourceKeepObjectsViolation" "for" "15m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookManagedResourceKeepObjectsViolation" "severity" "warning" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-managed-resource-keep-objects-violation/ #TODO: add playbook
+      service: {{ dig "WebhookManagedResourceKeepObjectsViolation" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookManagedResourceKeepObjectsViolation" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "Labeled ManagedResource ships CRDs without spec.keepObjects=true."
+      description: "A labeled ManagedResource ships at least one CRD but does not set spec.keepObjects=true. Deleting that MR (intentionally or accidentally) would cascade-delete the shoot-side CRDs and every custom resource of those kinds. Fix by setting spec.keepObjects=true on the MR — the stamp still works either way, but the destructive shape needs to be addressed."
+{{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceForceReconcilePatchErrors | default false) }}
+  - alert: WebhookManagedResourceForceReconcilePatchErrors
+    expr: |
+      sum(rate(webhook_injector_managed_resource_force_reconcile_total{result="error"}[15m])) > 0
+    for: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "for" "15m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "severity" "warning" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-managed-resource-force-reconcile-patch-errors/ #TODO: add playbook
+      service: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "Failed to patch gardener.cloud/operation=reconcile on ManagedResource."
+      description: "webhook-injector stamped a ManagedResource Secret but failed to patch the gardener.cloud/operation=reconcile annotation on the parent MR. GRM may take up to its own watch/sync interval to notice the change rather than reconciling immediately — caBundle propagation to the shoot will still happen, but with extra latency."
+{{- end }}

--- a/charts/controlplane-operations/alerts/controlplane-remote.yaml
+++ b/charts/controlplane-operations/alerts/controlplane-remote.yaml
@@ -103,7 +103,7 @@ groups:
 {{- if not (.Values.prometheusRules.disabled.WebhookTargetStampErrors | default false) }}
   - alert: WebhookTargetStampErrors
     expr: |
-      sum(rate(webhook_injector_target_stamps_total{result="error"}[5m])) > 0
+      sum by (namespace, kind) (rate(webhook_injector_target_stamps_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookTargetStampErrors" "for" "10m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -112,14 +112,14 @@ groups:
       service: {{ dig "WebhookTargetStampErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
       support_group: {{ dig "WebhookTargetStampErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
     annotations:
-      summary: "Webhook caBundle apply to target cluster is failing."
-      description: "webhook-injector failed to apply MutatingWebhookConfiguration or ValidatingWebhookConfiguration to the target cluster — the freshly rotated caBundle is NOT reaching the admission webhooks and subsequent CR writes may be rejected with TLS errors."
+      summary: "{{`{{ $labels.kind }}`}} apply to shoot {{`{{ $labels.namespace }}`}} is failing."
+      description: "webhook-injector failed to apply {{`{{ $labels.kind }}`}} to the target cluster of shoot {{`{{ $labels.namespace }}`}}. The freshly rotated caBundle is NOT reaching the admission webhooks on that shoot and subsequent CR writes may be rejected with TLS errors."
 {{- end }}
 
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceStampErrors | default false) }}
   - alert: WebhookManagedResourceStampErrors
     expr: |
-      sum(rate(webhook_injector_managed_resource_stamps_total{result="error"}[5m])) > 0
+      sum by (namespace) (rate(webhook_injector_managed_resource_stamps_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookManagedResourceStampErrors" "for" "10m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -128,14 +128,14 @@ groups:
       service: {{ dig "WebhookManagedResourceStampErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
       support_group: {{ dig "WebhookManagedResourceStampErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
     annotations:
-      summary: "Webhook caBundle stamp on ManagedResource Secret is failing."
-      description: "webhook-injector failed to stamp the freshly rotated caBundle onto a labeled ManagedResource Secret on the hosting cluster — the embedded CRDs will not refresh in the shoot via gardener-resource-manager, and conversion webhooks for those CRDs will fail TLS once the old cert is pruned."
+      summary: "ManagedResource Secret caBundle stamp is failing on shoot {{`{{ $labels.namespace }}`}}."
+      description: "webhook-injector failed to stamp the freshly rotated caBundle onto a labeled ManagedResource Secret in namespace {{`{{ $labels.namespace }}`}}. The embedded CRDs will not refresh in the shoot via gardener-resource-manager, and conversion webhooks for those CRDs will fail TLS once the old cert is pruned. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the offending MR name."
 {{- end }}
 
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceUnhealthy | default false) }}
   - alert: WebhookManagedResourceUnhealthy
     expr: |
-      sum(rate(webhook_injector_managed_resource_unhealthy_total[5m])) > 0
+      sum by (namespace, condition, status) (rate(webhook_injector_managed_resource_unhealthy_total[5m])) > 0
     for: {{ dig "WebhookManagedResourceUnhealthy" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -144,14 +144,14 @@ groups:
       service: {{ dig "WebhookManagedResourceUnhealthy" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
       support_group: {{ dig "WebhookManagedResourceUnhealthy" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
     annotations:
-      summary: "ManagedResource reported as not healthy by gardener-resource-manager."
-      description: "A labeled ManagedResource has ResourcesApplied or ResourcesHealthy condition with Status != True, meaning GRM is unable to apply or keep the resources healthy in the shoot. caBundle propagation to shoot-side CRDs is degraded; check the MR's status conditions for Reason/Message."
+      summary: "ManagedResource on shoot {{`{{ $labels.namespace }}`}} is unhealthy ({{`{{ $labels.condition }}`}}={{`{{ $labels.status }}`}})."
+      description: "A labeled ManagedResource in namespace {{`{{ $labels.namespace }}`}} has condition {{`{{ $labels.condition }}`}} with status {{`{{ $labels.status }}`}} (expected True). gardener-resource-manager is unable to apply or keep the resources healthy in the shoot, so caBundle propagation to shoot-side CRDs is degraded. Check the MR's status conditions for Reason/Message and the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the affected MR name."
 {{- end }}
 
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceKeepObjectsViolation | default false) }}
   - alert: WebhookManagedResourceKeepObjectsViolation
     expr: |
-      sum(rate(webhook_injector_managed_resource_keep_objects_violations_total[5m])) > 0
+      sum by (namespace) (rate(webhook_injector_managed_resource_keep_objects_violations_total[5m])) > 0
     for: {{ dig "WebhookManagedResourceKeepObjectsViolation" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -160,14 +160,14 @@ groups:
       service: {{ dig "WebhookManagedResourceKeepObjectsViolation" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
       support_group: {{ dig "WebhookManagedResourceKeepObjectsViolation" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
     annotations:
-      summary: "Labeled ManagedResource ships CRDs without spec.keepObjects=true."
-      description: "A labeled ManagedResource ships at least one CRD but does not set spec.keepObjects=true. Deleting that MR (intentionally or accidentally) would cascade-delete the shoot-side CRDs and every custom resource of those kinds. Fix by setting spec.keepObjects=true on the MR — the stamp still works either way, but the destructive shape needs to be addressed."
+      summary: "ManagedResource on shoot {{`{{ $labels.namespace }}`}} ships CRDs without spec.keepObjects=true."
+      description: "A labeled ManagedResource in namespace {{`{{ $labels.namespace }}`}} ships at least one CRD but does not set spec.keepObjects=true. Deleting that MR (intentionally or accidentally) would cascade-delete the shoot-side CRDs and every custom resource of those kinds. Fix by setting spec.keepObjects=true on the MR — the stamp still works either way, but the destructive shape needs to be addressed. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the offending MR name."
 {{- end }}
 
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceForceReconcilePatchErrors | default false) }}
   - alert: WebhookManagedResourceForceReconcilePatchErrors
     expr: |
-      sum(rate(webhook_injector_managed_resource_force_reconcile_total{result="error"}[5m])) > 0
+      sum by (namespace) (rate(webhook_injector_managed_resource_force_reconcile_total{result="error"}[5m])) > 0
     for: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "for" "15m" .Values.prometheusRules }}
     labels:
       {{ include "controlplane-operations.additionalRuleLabels" . }}
@@ -176,6 +176,6 @@ groups:
       service: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
       support_group: {{ dig "WebhookManagedResourceForceReconcilePatchErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
     annotations:
-      summary: "Failed to patch gardener.cloud/operation=reconcile on ManagedResource."
-      description: "webhook-injector stamped a ManagedResource Secret but failed to patch the gardener.cloud/operation=reconcile annotation on the parent MR. GRM may take up to its own watch/sync interval to notice the change rather than reconciling immediately — caBundle propagation to the shoot will still happen, but with extra latency."
+      summary: "gardener.cloud/operation=reconcile patch failing on shoot {{`{{ $labels.namespace }}`}}."
+      description: "webhook-injector stamped a ManagedResource Secret in namespace {{`{{ $labels.namespace }}`}} but failed to patch the gardener.cloud/operation=reconcile annotation on the parent MR. gardener-resource-manager may take up to its own watch/sync interval to notice the change rather than reconciling immediately — caBundle propagation to the shoot will still happen, but with extra latency. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the affected MR name."
 {{- end }}

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:
-  version: 1.1.11
+  version: 1.1.12
   displayName: Controlplane operations bundle
   description: Operations bundle for Controlane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: controlplane-operations
     repository: oci://ghcr.io/cloudoperators/controlplane-operations/charts
-    version: 1.1.11
+    version: 1.1.12
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: 1.1.13
   displayName: Controlplane operations bundle
-  description: Operations bundle for Controlane clusters
+  description: Operations bundle for Controlplane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
   icon: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/charts/controlplane-operations/kubernetes-logo.png
   helmChart:

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:
-  version: 1.1.10
+  version: 1.1.11
   displayName: Controlplane operations bundle
   description: Operations bundle for Controlane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: controlplane-operations
     repository: oci://ghcr.io/cloudoperators/controlplane-operations/charts
-    version: 1.1.10
+    version: 1.1.11
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:
-  version: 1.1.12
+  version: 1.1.13
   displayName: Controlplane operations bundle
   description: Operations bundle for Controlane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: controlplane-operations
     repository: oci://ghcr.io/cloudoperators/controlplane-operations/charts
-    version: 1.1.12
+    version: 1.1.13
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
Adds five new alerts to `controlplane-remote.yaml` covering the propagation-path metrics that [webhook-injector](https://github.com/SAP-cloud-infrastructure/webhook-injector) exposes.

The two existing alerts added in #23 (`WebhookCertificateNearExpiry`, `WebhookCertificateAboutToExpire`) cover the cert expiry side. These five cover the **apply / stamp / GRM-bridge** side that is just as important for caBundle freshness reaching the shoot — if the cert rotates but the caBundle doesn't propagate, every TLS call from the shoot apiserver to the webhook server still breaks.

## What's added

| Alert | Severity | For | What it catches |
|---|---|---|---|
| `WebhookTargetStampErrors` | critical | 10m | `target_stamps_total{result="error"}` rate > 0 — MWC/VWC apply on the target cluster is failing. The freshly rotated caBundle is not reaching the admission webhooks; CR writes may be rejected with TLS errors. |
| `WebhookManagedResourceStampErrors` | critical | 10m | `managed_resource_stamps_total{result="error"}` rate > 0 — MR Secret stamping on the hosting cluster is failing. Embedded CRDs will not refresh in the shoot via GRM. Conversion webhooks for those CRDs will fail TLS once the old cert is pruned. |
| `WebhookManagedResourceUnhealthy` | warning | 15m | `managed_resource_unhealthy_total` rate > 0 — a labeled MR has `ResourcesApplied` or `ResourcesHealthy` condition with `Status != True`. GRM can't apply or keep the resources healthy in the shoot. |
| `WebhookManagedResourceKeepObjectsViolation` | warning | 15m | `keep_objects_violations_total` rate > 0 — a labeled MR ships CRDs without `spec.keepObjects=true`. Destructive shape: deleting that MR would cascade-delete every shoot CRD it carries and every CR of those kinds. |
| `WebhookManagedResourceForceReconcilePatchErrors` | warning | 15m | `force_reconcile_total{result="error"}` rate > 0 — patching `gardener.cloud/operation=reconcile` on MRs is failing. GRM still picks up the change on its own watch/sync cadence, but with extra latency. |

The metric names and the "this counter is the alertable signal" framing come directly from [the webhook-injector docs](https://github.com/SAP-cloud-infrastructure/webhook-injector/blob/main/CLAUDE.md#metrics) — each metric here is one the docs explicitly flag as alertable.

## Style

Follows the exact convention of the existing alerts in this file (Argora + webhook cert):
- `{{ if not .Values.prometheusRules.disabled.<AlertName> }}` toggle per alert
- `{{ dig "<AlertName>" "for"|"severity"|"service"|"support_group" "<default>" .Values.prometheusRules }}` for all four labels
- `{{ include "controlplane-operations.additionalRuleLabels" . }}` for global labels
- Playbook URL placeholder with `#TODO: add playbook` comment
- Block-scalar `expr: |` matching the existing webhook-cert alerts

## Verification

```
$ helm lint charts/controlplane-operations
==> Linting charts/controlplane-operations
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template charts/controlplane-operations | yq '... | select(.kind=="PrometheusRule" and .metadata.name=="release-name-alerts-controlplane-remote") | .spec' | promtool check rules /dev/stdin
SUCCESS: 11 rules found
```

All 11 alerts (6 existing + 5 new) parse correctly. PromQL syntax + label keys + rule structure validated.

## Disabling

Each alert can be individually disabled via the existing pattern:

```yaml
prometheusRules:
  disabled:
    WebhookTargetStampErrors: true
    WebhookManagedResourceStampErrors: true
    # etc.
```