### PR TITLE
Add WebhookCertificateRotationDeferredByUnhealthyMRs alert

### DIFF
--- a/charts/controlplane-operations/Chart.yaml
+++ b/charts/controlplane-operations/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controlplane-operations
-version: 1.1.13
+version: 1.1.14
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Controlplane clusters.
 maintainers:
   - name: Vladimir Videlov (d051408)

--- a/charts/controlplane-operations/alerts/controlplane-remote.yaml
+++ b/charts/controlplane-operations/alerts/controlplane-remote.yaml
@@ -179,3 +179,19 @@ groups:
       summary: "gardener.cloud/operation=reconcile patch failing on shoot {{`{{ $labels.namespace }}`}}."
       description: "webhook-injector stamped a ManagedResource Secret in namespace {{`{{ $labels.namespace }}`}} but failed to patch the gardener.cloud/operation=reconcile annotation on the parent MR. gardener-resource-manager may take up to its own watch/sync interval to notice the change rather than reconciling immediately — caBundle propagation to the shoot will still happen, but with extra latency. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the affected MR name."
 {{- end }}
+
+{{- if not (.Values.prometheusRules.disabled.WebhookCertificateRotationDeferredByUnhealthyMRs | default false) }}
+  - alert: WebhookCertificateRotationDeferredByUnhealthyMRs
+    expr: |
+      sum by (namespace) (rate(webhook_injector_certificate_rotation_deferred_unhealthy_mrs_total[5m])) > 0
+    for: {{ dig "WebhookCertificateRotationDeferredByUnhealthyMRs" "for" "15m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookCertificateRotationDeferredByUnhealthyMRs" "severity" "warning" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-certificate-rotation-deferred-by-unhealthy-mrs/ #TODO: add playbook
+      service: {{ dig "WebhookCertificateRotationDeferredByUnhealthyMRs" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookCertificateRotationDeferredByUnhealthyMRs" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "Certificate rotation on shoot {{`{{ $labels.namespace }}`}} is being held back by unhealthy ManagedResources."
+      description: "webhook-injector observed a non-force certificate rotation reason (expired/san_mismatch/etc.) on shoot {{`{{ $labels.namespace }}`}} but is deferring the rotation because at least one labeled ManagedResource has ResourcesApplied or ResourcesHealthy != True. The existing cert keeps being served; rotation will resume automatically when the MR(s) recover. If the cert reaches NotAfter before that happens, the rotation will proceed anyway with a louder warning log — but webhook calls on shoot-side CRDs may TLS-fail during the gap. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the offending MR names, and the GRM/MR status for the underlying cause."
+{{- end }}

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:
-  version: 1.1.13
+  version: 1.1.14
   displayName: Controlplane operations bundle
   description: Operations bundle for Controlplane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: controlplane-operations
     repository: oci://ghcr.io/cloudoperators/controlplane-operations/charts
-    version: 1.1.13
+    version: 1.1.14
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
## Summary

Adds one new alert to `controlplane-remote.yaml`, companion to a behavior change in webhook-injector that ships in [SAP-cloud-infrastructure/webhook-injector#12](https://github.com/SAP-cloud-infrastructure/webhook-injector/pull/12).

## What the alert tracks

webhook-injector now defers a non-force cert rotation (`expired`, `san_mismatch`) when at least one labeled ManagedResource has a `ResourcesApplied` or `ResourcesHealthy` condition with `Status != True`. The cert keeps being served from the existing valid leaf; rotation resumes automatically when MR(s) recover. If the cert reaches `NotAfter` before that happens, an escape hatch lets the rotation proceed regardless with a louder warning log.

The new counter `webhook_injector_certificate_rotation_deferred_unhealthy_mrs_total` increments per deferred reconcile pass **and** per past-`NotAfter` under-duress rotation. This alert fires on a sustained non-zero rate.

## Alert definition

```yaml
- alert: WebhookCertificateRotationDeferredByUnhealthyMRs
  expr: sum by (namespace) (rate(webhook_injector_certificate_rotation_deferred_unhealthy_mrs_total[5m])) > 0
  for: 15m
  severity: warning
```

Style matches the other webhook-injector propagation alerts in the same file: `sum by (namespace)`, 5m rate window, dig-based overrides, `{{ $labels.namespace }}`-enriched summary/description, playbook URL placeholder with `#TODO: add playbook`.

## Operator runbook (short version)

When this fires:

1. Check the `WebhookManagedResourceUnhealthy` alert (also in this file) — should be firing for the same namespace, telling you which condition is bad.
2. Fix the underlying GRM/MR issue.
3. The deferred rotation will resume automatically. If the cert is approaching expiry, `WebhookCertificateNearExpiry` (and ultimately `AboutToExpire`) fire as the safety net — at which point the escape hatch in webhook-injector will rotate anyway.

## Migration note

Why this is a separate PR from #26: the alert was originally added to #26 by accident **after** that PR had already been merged. The original push targeted the closed branch. This PR cleans that up by re-applying the change on a fresh branch off the post-merge `main`.

## Verification

```
$ helm lint charts/controlplane-operations
1 chart(s) linted, 0 chart(s) failed

$ helm template ... | promtool check rules /dev/stdin
SUCCESS: 12 rules found
```

(was 11 on main, +1 from this PR)

Chart + plugindefinition version bumped `1.1.13` → `1.1.14`.