### PR TITLE
Add WebhookTargetCRDStampErrors alert for patch-mode CRD caBundle stamping

### DIFF
--- a/charts/controlplane-operations/alerts/controlplane-remote.yaml
+++ b/charts/controlplane-operations/alerts/controlplane-remote.yaml
@@ -116,6 +116,22 @@ groups:
       description: "webhook-injector failed to apply {{`{{ $labels.kind }}`}} to the target cluster of shoot {{`{{ $labels.namespace }}`}}. The freshly rotated caBundle is NOT reaching the admission webhooks on that shoot and subsequent CR writes may be rejected with TLS errors."
 {{- end }}
 
+{{- if not (.Values.prometheusRules.disabled.WebhookTargetCRDStampErrors | default false) }}
+  - alert: WebhookTargetCRDStampErrors
+    expr: |
+      sum by (namespace) (rate(webhook_injector_target_crd_stamps_total{result="error"}[5m])) > 0
+    for: {{ dig "WebhookTargetCRDStampErrors" "for" "10m" .Values.prometheusRules }}
+    labels:
+      {{ include "controlplane-operations.additionalRuleLabels" . }}
+      severity: {{ dig "WebhookTargetCRDStampErrors" "severity" "critical" .Values.prometheusRules }}
+      playbook: https://operations.global.cloud.sap/docs/support/playbook/webhook-target-crd-stamp-errors/ #TODO: add playbook
+      service: {{ dig "WebhookTargetCRDStampErrors" "service" .Values.prometheusRules.defaultService .Values.prometheusRules }}
+      support_group: {{ dig "WebhookTargetCRDStampErrors" "support_group" .Values.prometheusRules.defaultSupportGroup .Values.prometheusRules }}
+    annotations:
+      summary: "CRD conversion-webhook caBundle stamp to shoot {{`{{ $labels.namespace }}`}} is failing."
+      description: "webhook-injector (target patch mode, --target-label) failed to patch spec.conversion.webhook.clientConfig.caBundle on a labeled CustomResourceDefinition directly applied to the target cluster of shoot {{`{{ $labels.namespace }}`}}. The freshly rotated caBundle is NOT reaching the CRD's conversion webhook, so conversion calls for those custom resources will fail TLS once the old cert is pruned. This is the GRM-free / direct-apply counterpart of WebhookManagedResourceStampErrors. Check the webhook-injector logs in namespace {{`{{ $labels.namespace }}`}} for the offending CRD name."
+{{- end }}
+
 {{- if not (.Values.prometheusRules.disabled.WebhookManagedResourceStampErrors | default false) }}
   - alert: WebhookManagedResourceStampErrors
     expr: |


### PR DESCRIPTION
## Summary

Adds a `WebhookTargetCRDStampErrors` alert to `controlplane-remote.yaml`, covering the new `webhook_injector_target_crd_stamps_total{result="error"}` metric introduced by webhook-injector's opt-in **target patch mode** (`--target-label`, SAP-cloud-infrastructure/webhook-injector#14).

In the GRM-free / direct-apply topology (e.g. `dual-deployment-operator`), the injector patches `caBundle` directly onto CRD conversion webhooks on the target cluster and records the outcome in this new per-CRD counter. A sustained `result="error"` rate means the freshly rotated `caBundle` is not reaching those CRDs, so their conversion webhooks will fail TLS once the old cert is pruned — the direct-apply counterpart of the existing `WebhookManagedResourceStampErrors` (GRM path) and `WebhookTargetStampErrors` (MWC/VWC).

## Why a new alert (and not just reuse an existing one)

- Patch-mode **MWC/VWC** errors are already covered — they reuse `target_stamps_total`, which `WebhookTargetStampErrors` already alerts on.
- Patch-mode **CRDs** use a **separate** counter (`target_crd_stamps_total`) so the `kind` label enum on `target_stamps_total` stays bounded. That separate counter had no alert — this PR fills that single gap.

## Details

- Mirrors `WebhookTargetStampErrors` exactly: same `sum by (namespace) (rate(...[5m])) > 0` shape, `critical` severity, 10m `for`, `dig`-templated `for`/`severity`/`service`/`support_group`, `disabled.WebhookTargetCRDStampErrors` toggle, shared `additionalRuleLabels` include, `#TODO: add playbook` placeholder.
- Placed immediately after `WebhookTargetStampErrors` in the `controlplane-remote` group.

## Sequencing

⚠️ **Merge only after [SAP-cloud-infrastructure/webhook-injector#14](https://github.com/SAP-cloud-infrastructure/webhook-injector/pull/14) merges and ships in a released image.** Until then the `webhook_injector_target_crd_stamps_total` metric emits no series, so the alert would be inert. No harm if it lands earlier (it simply never fires), but the intended order is injector-first.

## Testing

- The rule follows the exact template of the sibling webhook alerts already in this file; renders under the same `disabled`/`dig` value conventions in `values.yaml`.
- Recommend a `helm template` + `promtool check rules` pass in CI as with the other alert PRs.