### PR TITLE
Bump chart version to 1.1.15 for WebhookTargetCRDStampErrors alert

### DIFF
--- a/charts/controlplane-operations/Chart.yaml
+++ b/charts/controlplane-operations/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controlplane-operations
-version: 1.1.14
+version: 1.1.15
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Controlplane clusters.
 maintainers:
   - name: Vladimir Videlov (d051408)

--- a/charts/controlplane-operations/plugindefinition.yaml
+++ b/charts/controlplane-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: controlplane-operations
 spec:
-  version: 1.1.14
+  version: 1.1.15
   displayName: Controlplane operations bundle
   description: Operations bundle for Controlplane clusters
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/controlplane-operations/main/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: controlplane-operations
     repository: oci://ghcr.io/cloudoperators/controlplane-operations/charts
-    version: 1.1.14
+    version: 1.1.15
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
## Summary

Patch-bumps the chart + plugin version `1.1.14` → `1.1.15` for the additive `WebhookTargetCRDStampErrors` alert merged in #28.

The alert PR (#28) added a new Prometheus rule but did not bump the version; this PR does the follow-up bump so the change ships in a new chart release.

## Changes

- `charts/controlplane-operations/Chart.yaml`: `version` → `1.1.15`
- `charts/controlplane-operations/plugindefinition.yaml`: `spec.version` and `helmChart.version` → `1.1.15` (in lockstep with the chart, matching the existing convention)

## Convention

Follows the additive-alert bump cadence from #26 (patch bump per additive webhook-injector alert PR). No behavior change beyond the version metadata — the alert itself already landed in #28.

## References

- Alert PR: #28
- Upstream feature: SAP-cloud-infrastructure/webhook-injector#14 (introduces the `webhook_injector_target_crd_stamps_total` metric the alert consumes)